### PR TITLE
This should fix issue #4. Now the last entry in dictionary.txt is inc…

### DIFF
--- a/plugins/dictionary/plugin.go
+++ b/plugins/dictionary/plugin.go
@@ -136,14 +136,9 @@ func (p *plugin) loadFile() error {
 				continue
 			}
 
-			idx := indexOf(p.definitions, line)
-			if idx > -1 {
-				indices = append(indices, idx)
-				continue
-			}
-
-			indices = append(indices, len(p.definitions))
 			p.definitions = append(p.definitions, line)
+			idx := indexOf(p.definitions, line)
+			indices = append(indices, idx)
 			continue
 		}
 
@@ -157,6 +152,13 @@ func (p *plugin) loadFile() error {
 		// We have a new set of terms to be defined.
 		terms = split(line, ",")
 		indices = nil
+	}
+
+	// Store indices for last terms in the file, if applicable.
+	if len(terms) > 0 && len(indices) > 0 {
+		for _, t := range terms {
+			p.terms[t] = indices
+		}
 	}
 
 	return scn.Err()

--- a/plugins/dictionary/plugin.go
+++ b/plugins/dictionary/plugin.go
@@ -136,9 +136,15 @@ func (p *plugin) loadFile() error {
 				continue
 			}
 
-			p.definitions = append(p.definitions, line)
 			idx := indexOf(p.definitions, line)
-			indices = append(indices, idx)
+			if idx >= -1 {
+				// no need to append duplicate definition
+				indices = append(indices, idx)
+				continue
+			}
+
+			p.definitions = append(p.definitions, line)
+			indices = append(indices, len(p.definitions)-1)
 			continue
 		}
 

--- a/plugins/dictionary/plugin.go
+++ b/plugins/dictionary/plugin.go
@@ -137,7 +137,7 @@ func (p *plugin) loadFile() error {
 			}
 
 			idx := indexOf(p.definitions, line)
-			if idx >= -1 {
+			if idx > -1 {
 				// no need to append duplicate definition
 				indices = append(indices, idx)
 				continue


### PR DESCRIPTION
#…luded in the terms array.

@monkeybird please review the way I fixed it. There is now a duplicated codeblock (`if len(terms) > 0 ...` appears twice). I think the duplication is ugly, but maybe still the way to do it?